### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -10,6 +10,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/ronnypolley/pitest-report-action/security/code-scanning/2](https://github.com/ronnypolley/pitest-report-action/security/code-scanning/2)

To fix the problem, explicitly define a minimal `permissions` block so the `GITHUB_TOKEN` used by this workflow has only the rights it needs. For this CI job, checking out code and running builds/tests only require read access to repository contents, so `contents: read` at either the workflow or job level is an appropriate baseline. If, in the future, additional capabilities are required (for example, creating issues or updating PRs), they can be added selectively.

The best way to fix this without changing existing behavior is to add a `permissions` block at the root of the workflow (so it applies to all jobs) just after the `on:` section and before `jobs:`. Concretely, in `.github/workflows/node.js.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` block (lines 6–11) and the `jobs:` block (line 13). This constrains the `GITHUB_TOKEN` to read-only repository contents while preserving all current functionality: `actions/checkout` works with `contents: read`, and the SonarCloud action uses `SONAR_TOKEN` for analysis and only needs `GITHUB_TOKEN` with read permissions for metadata if at all.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
